### PR TITLE
Special seasoning update

### DIFF
--- a/kol/diet-code-1.0.0.js
+++ b/kol/diet-code-1.0.0.js
@@ -177,7 +177,12 @@ function tehtmi(diet_settings) {
 		var sum = 0.0
 		var count = 0.0
 		if(item["advmax"] == 0) return 0
-		for(var base_adv = item["advmin"]; base_adv <= item["advmax"]; ++base_adv) {
+		// Special seasoning increases the minimum adventures by 1
+		// If the delta between min and max is 0, then max is also increased by 1
+		const seasoningBonus = opts["special seasoning"] ? 1 : 0
+		const min = item["advmin"] + seasoningBonus
+		const max = item["advmax"] === item["advmin"] ? min : item["advmax"]
+		for(var base_adv = min; base_adv <= max; ++base_adv) {
 			var adv = base_adv
 			
 			if(opts["munchies pill"]) {
@@ -245,10 +250,6 @@ function tehtmi(diet_settings) {
 			}
 			
 			if(opts["mayoflex"]) {
-				adv += 1
-			}
-			
-			if(opts["special seasoning"]) {
 				adv += 1
 			}
 

--- a/kol/diet-code-1.0.0.js
+++ b/kol/diet-code-1.0.0.js
@@ -179,9 +179,9 @@ function tehtmi(diet_settings) {
 		if(item["advmax"] == 0) return 0
 		// Special seasoning increases the minimum adventures by 1
 		// If the delta between min and max is 0, then max is also increased by 1
-		const seasoningBonus = opts["special seasoning"] ? 1 : 0
-		const min = item["advmin"] + seasoningBonus
-		const max = item["advmax"] === item["advmin"] ? min : item["advmax"]
+		var seasoning_bonus = opts["special seasoning"] ? 1 : 0
+		var min = item["advmin"] + seasoning_bonus
+		var max = item["advmax"] === item["advmin"] ? min : item["advmax"]
 		for(var base_adv = min; base_adv <= max; ++base_adv) {
 			var adv = base_adv
 			
@@ -315,7 +315,8 @@ function tehtmi(diet_settings) {
 			}
 		}
 		if(item["type"] == "food" && special_seasoning_item) {
-			if(special_seasoning_item["price"] + k_epsilon < adv_value) {
+			var max_seasoning_value = item["advmin"] === item["advmax"] ? adv_value : 0.5 * adv_value;
+			if(special_seasoning_item["price"] + k_epsilon < max_seasoning_value) {
 				opts["special seasoning"] = true
 			}
 		}

--- a/kol/diet-ui-1.0.0.js
+++ b/kol/diet-ui-1.0.0.js
@@ -128,7 +128,7 @@ function item_tooltip(e, elt, item, desc, settings) {
 			}
 			if(opts["special seasoning"]) {
 				summary = true
-				add_row("\u2192 Special Seasoning", "+1")
+				add_row("\u2192 Special Seasoning", item.advmin == item.advmax ? "+1" : "+0.5")
 			}
 			if(opts["whet stone"]) {
 				summary = true


### PR DESCRIPTION
Oddly enough, special seasoning isn't a flat +1 adventure to food consumed. In general it's worth half an adventure, however in the case of foods with fixed adventure gain, it is still worth the +1 adventure.

Preview of the change:
![image](https://user-images.githubusercontent.com/49845237/217089131-24126624-2da0-4d03-b864-d875615d06d5.png)